### PR TITLE
Pin Hugo version for Netlify build

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,8 @@
+[build]
+  command = "hugo"
+  publish = "public"
+
+[build.environment]
+  # Pinned: ghostwriter theme uses .Site.LastChange (removed in Hugo 0.141.0)
+  # and the pre-rename _internal/disqus.html template, so it needs Hugo <= 0.140.x.
+  HUGO_VERSION = "0.140.2"


### PR DESCRIPTION
Netlify dropped its bundled Hugo, causing 'hugo: command not found' (exit 127) on every build. This adds a netlify.toml pinning HUGO_VERSION=0.140.2 — the last release compatible with the vendored ghostwriter theme (newer Hugo removed .Site.LastChange and renamed the internal disqus template). Verified the site builds cleanly with this version locally.