### PR TITLE
Fix .Site.LastChange deprecation breaking Hugo build

### DIFF
--- a/themes/ghostwriter/layouts/partials/footer.html
+++ b/themes/ghostwriter/layouts/partials/footer.html
@@ -13,7 +13,7 @@
                 </div>
 
                 <p class="footer-copyright">
-                    <span>&copy; {{ .Site.LastChange.Format "2006" }} / Powered by <a href="https://gohugo.io/">Hugo</a></span>
+                    <span>&copy; {{ .Site.Lastmod.Format "2006" }} / Powered by <a href="https://gohugo.io/">Hugo</a></span>
                 </p>
                 <p class="footer-copyright">
                     <span><a href="https://github.com/roryg/ghostwriter">Ghostwriter theme</a> By <a href="http://jollygoodthemes.com">JollyGoodThemes</a></span>


### PR DESCRIPTION
The Netlify build now finds Hugo 0.140.2 but fails because the ghostwriter footer uses .Site.LastChange, which Hugo 0.140.2 logs at ERROR level (failing the build). Replaced with .Site.Lastmod. Verified `hugo` builds the full site with exit 0 locally.