### PR TITLE
Ignore local .netlify folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 public
+# Local Netlify folder
+.netlify


### PR DESCRIPTION
The .netlify folder is created by 'netlify link' and holds local link state (state.json) that should not be committed.