### PR TITLE
Remove Twitter profile link from header

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 public
 # Local Netlify folder
 .netlify
+# Hugo build lock file
+.hugo_build.lock

--- a/themes/ghostwriter/layouts/partials/header.html
+++ b/themes/ghostwriter/layouts/partials/header.html
@@ -38,11 +38,6 @@
                             </h1>
                         {{ end }}
                         <a class="button-square" href="{{ .Site.BaseURL }}index.xml"><i class="fa fa-rss"></i></a>
-                        {{ with .Site.Params.twitter }}
-                            <a class="button-square button-social hint--top" data-hint="Twitter" title="Twitter" href="{{ . }}" rel="me">
-                                <i class="fa fa-twitter"></i>
-                            </a>
-                        {{ end }}
                         {{ with .Site.Params.facebook }}
                             <a class="button-square button-social hint--top" data-hint="Facebook" title="Facebook" href="{{ . }}" rel="me">
                                 <i class="fa fa-facebook"></i>


### PR DESCRIPTION
Removes the Twitter social icon/link from the site header partial. Also adds .hugo_build.lock to .gitignore. Verified the site builds with exit 0 and no fa-twitter in the header.