### PR TITLE
Remove Twitter via config rather than theme edit

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -9,7 +9,6 @@ googleAnalytics = "UA-1642022-7"
     intro = true
     description = "CEO and Co-founder at Cronofy. Previously CTO and Co-founder at Esendex. Anti time waster, (ex)developer, cyclist and champion of state education."
     linkedin = "https://linkedin.com/in/adambird/"
-    twitter = "https://twitter.com/adambird"
     opengraph = true
     shareTwitter = true
     shareFacebook = true

--- a/themes/ghostwriter/layouts/partials/header.html
+++ b/themes/ghostwriter/layouts/partials/header.html
@@ -38,6 +38,11 @@
                             </h1>
                         {{ end }}
                         <a class="button-square" href="{{ .Site.BaseURL }}index.xml"><i class="fa fa-rss"></i></a>
+                        {{ with .Site.Params.twitter }}
+                            <a class="button-square button-social hint--top" data-hint="Twitter" title="Twitter" href="{{ . }}" rel="me">
+                                <i class="fa fa-twitter"></i>
+                            </a>
+                        {{ end }}
                         {{ with .Site.Params.facebook }}
                             <a class="button-square button-social hint--top" data-hint="Facebook" title="Facebook" href="{{ . }}" rel="me">
                                 <i class="fa fa-facebook"></i>


### PR DESCRIPTION
Cleaner approach: restore the vendored ghostwriter header template to upstream and remove the twitter param from config.toml. The header is gated by {{ with .Site.Params.twitter }}, so dropping the config removes the link with no theme changes. Verified build exit 0 and no fa-twitter in the header.