### PR TITLE
Remove Twitter share button (config-driven)

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -10,7 +10,6 @@ googleAnalytics = "UA-1642022-7"
     description = "CEO and Co-founder at Cronofy. Previously CTO and Co-founder at Esendex. Anti time waster, (ex)developer, cyclist and champion of state education."
     linkedin = "https://linkedin.com/in/adambird/"
     opengraph = true
-    shareTwitter = true
     shareFacebook = true
     shareLinkedIn = true
     dateFormat = "Mon, Jan 2, 2006"

--- a/themes/ghostwriter/layouts/partials/post-footer.html
+++ b/themes/ghostwriter/layouts/partials/post-footer.html
@@ -11,20 +11,26 @@
     {{ end}}
 
     <div class="share">
+            {{ if .Site.Params.shareTwitter }}
             <a class="icon-twitter" href="https://twitter.com/share?text={{ .Title }}&url={{ .Permalink }}"
                 onclick="window.open(this.href, 'twitter-share', 'width=550,height=235');return false;">
                 <i class="fa fa-twitter"></i>
                 <span class="hidden">Twitter</span>
             </a>
+            {{ end }}
+            {{ if .Site.Params.shareFacebook }}
             <a class="icon-facebook" href="https://www.facebook.com/sharer/sharer.php?u={{ .Permalink }}"
                 onclick="window.open(this.href, 'facebook-share','width=580,height=296');return false;">
                 <i class="fa fa-facebook"></i>
                 <span class="hidden">Facebook</span>
             </a>
+            {{ end }}
+            {{ if .Site.Params.shareLinkedIn }}
             <a class="icon-linkedin" href="https://www.linkedin.com/shareArticle?mini=true&title={{ .Title }}&url={{ .Permalink }}&summary={{ .Description }}"
                onclick="window.open(this.href, 'linkedin-share', 'width=554,height=481');return false;">
                <i class="fa fa-linkedin"></i>
                <span class="hidden">LinkedIn</span>
             </a>
+            {{ end }}
     </div>
 </footer>


### PR DESCRIPTION
The post-footer share buttons were hardcoded, so the existing share* config params did nothing. Gate each share link on its .Site.Params.shareX flag, then remove shareTwitter from config.toml to drop the Twitter share button. Facebook/LinkedIn retained. Verified build exit 0: twitter share = 0, facebook/linkedin = 1.